### PR TITLE
Fix Neo4j startup by setting stronger default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ A minimal scaffold for a "second brain" application with a Python backend, Neo4j
 
 ## Running with Docker Compose
 
+Set a `NEO4J_PASSWORD` (minimum 8 characters) for the Neo4j admin user.
 Provide an `OPENAI_API_KEY` if you want embeddings to be generated during ingestion. Then run:
 
 ```bash
+export NEO4J_PASSWORD=secretsecret
+export OPENAI_API_KEY=...
 docker compose up --build
 ```
+
+Both values can be supplied via environment variables or a `.env` file used by Docker Compose.
 
 Services:
 - **neo4j** – graph database on ports `7474` (HTTP) and `7687` (bolt)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,9 @@ app.add_middleware(
 
 NEO4J_URI = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
 NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
-NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "secret")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD")
+if not NEO4J_PASSWORD:
+    raise ValueError("NEO4J_PASSWORD environment variable must be set")
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if OPENAI_API_KEY:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   neo4j:
     image: neo4j:5
     environment:
-      - NEO4J_AUTH=neo4j/secret
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
     ports:
       - "7474:7474"
       - "7687:7687"
@@ -16,7 +16,7 @@ services:
     environment:
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
-      - NEO4J_PASSWORD=secret
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
     depends_on:
       - neo4j


### PR DESCRIPTION
## Summary
- read `NEO4J_PASSWORD` from environment and fail fast if missing
- use `${NEO4J_PASSWORD}` in docker-compose for Neo4j and backend
- document setting the password and optional `OPENAI_API_KEY`, including export examples

## Testing
- `python -m py_compile backend/app/main.py`
- `pytest`
- ⚠️ `docker compose up --build` *(missing `docker` executable)*

------
https://chatgpt.com/codex/tasks/task_e_68af73931474832fba1a61198d5f663c